### PR TITLE
* Activate extension on debug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
         "debugger"
     ],
     "activationEvents": [
-        "onLanguage:kotlin"
+        "onLanguage:kotlin",
+		"onDebug"
     ],
     "main": "./dist/extension",
     "contributes": {


### PR DESCRIPTION
If VS Code doesn't open any .kt file from app startup, vscode-kotlin will not be activated. Then, if we run a vscode-kotlin debug configuration, it will show this error:
![image](https://user-images.githubusercontent.com/49478723/85202270-cc470100-b337-11ea-8fad-4ddcaacb0682.png)

This commit fixes this problem.