### PR TITLE
Add storage path

### DIFF
--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -68,9 +68,9 @@ export async function activateLanguageServer(context: vscode.ExtensionContext, s
     
     const startScriptPath = customPath || path.resolve(langServerInstallDir, "server", "bin", correctScriptName("kotlin-language-server"));
 
-    const storagePath = context.storagePath
-    if (!fs.existsSync(storagePath)){
-        fs.mkdirSync(storagePath);
+    const storagePath = context.storageUri.fsPath
+    if (!(await fsExists(storagePath))) {
+        await fs.promises.mkdir(storagePath);
     }
 
     const options = { outputChannel, startScriptPath, tcpPort, env, storagePath };

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -67,7 +67,13 @@ export async function activateLanguageServer(context: vscode.ExtensionContext, s
     status.dispose();
     
     const startScriptPath = customPath || path.resolve(langServerInstallDir, "server", "bin", correctScriptName("kotlin-language-server"));
-    const options = { outputChannel, startScriptPath, tcpPort, env };
+
+    const storagePath = context.storagePath
+    if (!fs.existsSync(storagePath)){
+        fs.mkdirSync(storagePath);
+    }
+
+    const options = { outputChannel, startScriptPath, tcpPort, env, storagePath };
     const languageClient = createLanguageClient(options);
 
     // Create the language client and start the client.
@@ -96,7 +102,8 @@ function createLanguageClient(options: {
     outputChannel: vscode.OutputChannel,
     startScriptPath: string,
     tcpPort?: number,
-    env?: any
+    env?: any,
+    storagePath: string
 }): LanguageClient {
     // Options to control the language client
     const clientOptions: LanguageClientOptions = {
@@ -122,7 +129,10 @@ function createLanguageClient(options: {
         },
         progressOnInitialization: true,
         outputChannel: options.outputChannel,
-        revealOutputChannelOn: RevealOutputChannelOn.Never
+        revealOutputChannelOn: RevealOutputChannelOn.Never,
+        initializationOptions: {
+            storagePath: options.storagePath
+        }
     }
     
     // Ensure that start script can be executed


### PR DESCRIPTION
Sends the extension's workspace storage path to the server, so it can be used by the server to cache things (see https://github.com/fwcd/kotlin-language-server/pull/337)

I can make this feature experimental (i.e., hidden behind a feature flag) if you'd prefer.