### PR TITLE
Debug code lens using new resolveMain command in Kotlin-Language-Server

### DIFF
--- a/src/RunDebugCodeLens.ts
+++ b/src/RunDebugCodeLens.ts
@@ -5,7 +5,6 @@ export class RunDebugCodeLens implements vscode.CodeLensProvider {
     async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
         const mainInfo = await vscode.commands.executeCommand("kotlin.resolveMain", document.uri.toString()) as MainInfo
 
-        // TODO: any way we can disable these buttons while it is running?
         if(mainInfo && mainInfo.mainClass) {
             return [
                 new vscode.CodeLens(

--- a/src/RunDebugCodeLens.ts
+++ b/src/RunDebugCodeLens.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+
+
+export class RunDebugCodeLens implements vscode.CodeLensProvider {
+    async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<vscode.CodeLens[]> {
+        const mainInfo = await vscode.commands.executeCommand("kotlin.resolveMain", document.uri.toString()) as MainInfo
+
+        // TODO: any way we can disable these buttons while it is running?
+        if(mainInfo && mainInfo.mainClass) {
+            return [
+                new vscode.CodeLens(
+                    mainInfo.range,
+                    {
+                        title: "Run",
+                        command: "kotlin.runMain",
+                        arguments: [mainInfo.mainClass, mainInfo.projectRoot]
+                    }
+                ),
+                new vscode.CodeLens(
+                    mainInfo.range,
+                    {
+                        title: "Debug",
+                        command: "kotlin.debugMain",
+                        arguments: [mainInfo.mainClass, mainInfo.projectRoot]
+                    }
+                )
+            ]
+        }
+        
+        return []
+    }
+}
+
+interface MainInfo {
+    mainClass: String,
+    projectRoot: String,
+    range: vscode.Range
+}

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -11,6 +11,7 @@ import { Status } from "./util/status";
 import { JarClassContentProvider } from "./jarClassContentProvider";
 import { fsExists } from "./util/fsUtils";
 import { RunDebugCodeLens } from "./RunDebugCodeLens";
+import { MainClassRequest } from "./lspExtensions";
 
 /** Downloads and starts the language server. */
 export async function activateLanguageServer(context: vscode.ExtensionContext, status: Status, config: vscode.WorkspaceConfiguration) {
@@ -96,9 +97,8 @@ export async function activateLanguageServer(context: vscode.ExtensionContext, s
         vscode.languages.registerCodeLensProvider("kotlin", new RunDebugCodeLens())
     
         vscode.commands.registerCommand("kotlin.resolveMain", async(fileUri) => {
-            return await languageClient.sendRequest("workspace/executeCommand", {
-                command: "resolveMain",
-                arguments: [fileUri]
+            return await languageClient.sendRequest(MainClassRequest.type, {
+                uri: fileUri
             })
         })
     

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -94,36 +94,36 @@ export async function activateLanguageServer(context: vscode.ExtensionContext, s
     const debugAdapterEnabled = kotlinConfig.get("debugAdapter.enabled");
     if(debugAdapterEnabled) {
         vscode.languages.registerCodeLensProvider("kotlin", new RunDebugCodeLens())
-    }
     
-    vscode.commands.registerCommand("kotlin.resolveMain", async(fileUri) => {
-        return await languageClient.sendRequest("workspace/executeCommand", {
-            command: "resolveMain",
-            arguments: [fileUri]
+        vscode.commands.registerCommand("kotlin.resolveMain", async(fileUri) => {
+            return await languageClient.sendRequest("workspace/executeCommand", {
+                command: "resolveMain",
+                arguments: [fileUri]
+            })
         })
-    })
     
-    // TODO: maybe the settings can be persisted in a launch.json?
-    vscode.commands.registerCommand("kotlin.runMain", async(mainClass, projectRoot) => {
-        vscode.debug.startDebugging(vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectRoot)), {
-            type: "kotlin",
-            name: "Run Kotlin main",
-            request: "launch",
-            noDebug: true,
-            mainClass,
-            projectRoot,
-        }) 
-    });
-
-    vscode.commands.registerCommand("kotlin.debugMain", async(mainClass, projectRoot) => {
-        vscode.debug.startDebugging(vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectRoot)), {
-            type: "kotlin",
-            name: "Debug Kotlin main",
-            request: "launch",
-            mainClass,
-            projectRoot,
-        }) 
-    });
+        // TODO: maybe the settings can be persisted in a launch.json?
+        vscode.commands.registerCommand("kotlin.runMain", async(mainClass, projectRoot) => {
+            vscode.debug.startDebugging(vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectRoot)), {
+                type: "kotlin",
+                name: "Run Kotlin main",
+                request: "launch",
+                noDebug: true,
+                mainClass,
+                projectRoot,
+            }) 
+        });
+        
+        vscode.commands.registerCommand("kotlin.debugMain", async(mainClass, projectRoot) => {
+            vscode.debug.startDebugging(vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectRoot)), {
+                type: "kotlin",
+                name: "Debug Kotlin main",
+                request: "launch",
+                mainClass,
+                projectRoot,
+            }) 
+        });
+    }
 
     await languageClient.onReady();
 }

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -102,7 +102,6 @@ export async function activateLanguageServer(context: vscode.ExtensionContext, s
             })
         })
     
-        // TODO: maybe the settings can be persisted in a launch.json?
         vscode.commands.registerCommand("kotlin.runMain", async(mainClass, projectRoot) => {
             vscode.debug.startDebugging(vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectRoot)), {
                 type: "kotlin",

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -4,3 +4,7 @@ import { TextDocumentIdentifier } from "vscode-languageclient";
 export namespace JarClassContentsRequest {
     export const type = new RequestType<TextDocumentIdentifier, string, void>("kotlin/jarClassContents");
 }
+
+export namespace MainClassRequest {
+    export const type = new RequestType<TextDocumentIdentifier, any, void>("kotlin/mainClass")
+}


### PR DESCRIPTION
Uses https://github.com/fwcd/kotlin-language-server/pull/345 to get information on the main method, so Kotlin-Debug-Adapter can be used to run or debug the code without creating launch.json files. Currently no persisting of these settings (to launch.json) are done, so this is a probable future improvement. 

Regular main method:
<img width="403" alt="Screenshot 2022-04-11 at 15 44 31" src="https://user-images.githubusercontent.com/5732795/162752991-481ba84e-be69-45b0-888e-968b10c33249.png">


Companion object main method:
<img width="411" alt="Screenshot 2022-04-11 at 15 44 08" src="https://user-images.githubusercontent.com/5732795/162753045-806c4a47-a727-4d4c-af9d-6a42430a807c.png">


You may wonder: What made me, a hardcore Emacs user do this stuff for VS Code? I have to admit I have a soft spot for VSCode, and TypeScript is fun. VSCode is also the editor I recommend to people starting out with coding, as I think it is one of the best editors that are not Emacs around. (Emacs is not for everyone, never will be probably, but the ability to choose what works best for you is great!). I'm by no means a pro in VSCode extension coding, so there are probably room for improvements 🙂 


Same functionality for Emacs is in progress in lsp-mode for lsp-kotlin, but not pleased yet. Proof if you are curious 😛 
https://github.com/themkat/lsp-mode/tree/kotlin_run_debug