### PR TITLE
General override member(s) functionality - VSCode version

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
                 "command": "kotlin.languageServer.restart",
                 "title": "Restart the Language Server",
                 "category": "Kotlin"
+            },
+            {
+                "command": "kotlin.overrideMember",
+                "title": "Override member(s)",
+                "category": "Kotlin"
             }
         ],
         "breakpoints": [

--- a/package.json
+++ b/package.json
@@ -71,6 +71,15 @@
                 "category": "Kotlin"
             }
         ],
+        "menus": {
+            "editor/context": [
+                {
+                    "command": "kotlin.overrideMember",
+                    "group": "Kotlin",
+                    "when": "editorTextFocus && editorLangId == kotlin"
+                }
+            ]
+        },
         "breakpoints": [
             {
                 "language": "kotlin"

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -1,4 +1,3 @@
-import { CodeAction } from "vscode";
 import { RequestType0, RequestType } from "vscode-jsonrpc";
 import { TextDocumentIdentifier, TextDocumentPositionParams } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
@@ -12,7 +11,7 @@ export namespace MainClassRequest {
 }
 
 export namespace OverrideMemberRequest {
-    export const type = new RequestType<TextDocumentPositionParams, CodeAction[], void>("kotlin/overrideMember");
+    export const type = new RequestType<TextDocumentPositionParams, any[], void>("kotlin/overrideMember");
 }
 
 export namespace BuildOutputLocationRequest {

--- a/src/lspExtensions.ts
+++ b/src/lspExtensions.ts
@@ -1,5 +1,6 @@
+import { CodeAction } from "vscode";
 import { RequestType0, RequestType } from "vscode-jsonrpc";
-import { TextDocumentIdentifier } from "vscode-languageclient";
+import { TextDocumentIdentifier, TextDocumentPositionParams } from "vscode-languageclient";
 import { LanguageClient } from "vscode-languageclient/node";
 
 export namespace JarClassContentsRequest {
@@ -7,7 +8,11 @@ export namespace JarClassContentsRequest {
 }
 
 export namespace MainClassRequest {
-    export const type = new RequestType<TextDocumentIdentifier, any, void>("kotlin/mainClass")
+    export const type = new RequestType<TextDocumentIdentifier, any, void>("kotlin/mainClass");
+}
+
+export namespace OverrideMemberRequest {
+    export const type = new RequestType<TextDocumentPositionParams, CodeAction[], void>("kotlin/overrideMember");
 }
 
 export namespace BuildOutputLocationRequest {


### PR DESCRIPTION
Simple VSCode usage of the override member protocol extension found in: https://github.com/fwcd/kotlin-language-server/pull/379 (need to be merged after that PR).


Have some TODOs I couldn't resolve for now. I suggest we keep that for future work. Currently this version does exactly the same as the Emacs version that was shown in the kotlin-language-server PR does. Have added a nifty right-click menu to override members that make it simple. No hotkey, but that is because I don't know what people would prefer. Feel free to suggest something 🙂 You can also run it with the command palette, using the command kotlin.overrideMember.


How the selection menu looks:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/5732795/183242236-311b8889-91c6-4f34-874f-0d0f995f184d.png">

And clicking okay and seeing the overrides added to your code:
<img width="896" alt="image" src="https://user-images.githubusercontent.com/5732795/183242254-ee46092d-fc67-4ab2-acb0-ae4b138e201a.png">


Hope this is something other people also want 🙂 I really wanted it, at least for Emacs 😛 