### PR TITLE
Make it possible to override JAVA_OPTS directly in the extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,6 +218,11 @@
                     "default": "",
                     "description": "A custom JAVA_HOME for the language server and debug adapter to use."
                 },
+                "kotlin.java.opts": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Custom options using JAVA_OPTS for the language server and debug adapter."
+                },
                 "kotlin.languageServer.enabled": {
                     "type": "boolean",
                     "default": true,

--- a/src/debugSetup.ts
+++ b/src/debugSetup.ts
@@ -5,7 +5,7 @@ import { ServerDownloader } from "./serverDownloader";
 import { correctScriptName, isOSUnixoid } from "./util/osUtils";
 import { ServerSetupParams } from "./setupParams";
 
-export async function registerDebugAdapter({ context, status, config, javaInstallation }: ServerSetupParams): Promise<void> {
+export async function registerDebugAdapter({ context, status, config, javaInstallation, javaOpts }: ServerSetupParams): Promise<void> {
     status.update("Registering Kotlin Debug Adapter...");
     
     // Prepare debug adapter
@@ -35,6 +35,10 @@ export async function registerDebugAdapter({ context, status, config, javaInstal
 
     if (javaInstallation.javaHome) {
         env['JAVA_HOME'] = javaInstallation.javaHome;
+    }
+
+    if (javaOpts) {
+        env['JAVA_OPTS'] = javaOpts;
     }
     
     vscode.debug.registerDebugAdapterDescriptorFactory("kotlin", new KotlinDebugAdapterDescriptorFactory(startScriptPath, env));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { registerDebugAdapter } from './debugSetup';
 import { InternalConfigManager } from './internalConfig';
-import { findJavaInstallation } from './javaSetup';
+import { findJavaInstallation, findJavaOpts } from './javaSetup';
 import { activateLanguageServer, configureLanguage } from './languageSetup';
 import { KotlinApi } from './lspExtensions';
 import { ServerSetupParams } from './setupParams';
@@ -58,11 +58,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
         return;
     }
 
+    const javaOpts = await findJavaOpts();
     const setupParams: (status: Status) => ServerSetupParams = status => ({
         context,
         status,
         config: kotlinConfig,
-        javaInstallation
+        javaInstallation,
+        javaOpts
     });
 
     let extensionApi = new ExtensionApi();

--- a/src/javaSetup.ts
+++ b/src/javaSetup.ts
@@ -77,3 +77,21 @@ async function findJavaExecutableInJavaHome(javaHome: string, binname: string): 
     
     return null;
 }
+
+export async function findJavaOpts(): Promise<string> {
+    let userJavaOpts = vscode.workspace.getConfiguration('kotlin').get('java.opts') as string;
+
+    if (userJavaOpts) {
+        LOG.debug("Using user settings JAVA_OPTS value");
+        return userJavaOpts;
+    }
+
+    let envJavaOpts = process.env["JAVA_OPTS"];
+
+    if (envJavaOpts) {
+        LOG.debug("Using environment variable JAVA_OPTS");
+        return envJavaOpts;
+    }
+
+    return "";
+}

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -15,7 +15,7 @@ import { RunDebugCodeLens } from "./runDebugCodeLens";
 import { MainClassRequest, OverrideMemberRequest } from "./lspExtensions";
 
 /** Downloads and starts the language server. */
-export async function activateLanguageServer({ context, status, config, javaInstallation }: ServerSetupParams): Promise<KotlinApi> {
+export async function activateLanguageServer({ context, status, config, javaInstallation, javaOpts }: ServerSetupParams): Promise<KotlinApi> {
     LOG.info('Activating Kotlin Language Server...');
     status.update("Activating Kotlin Language Server...");
     
@@ -44,6 +44,10 @@ export async function activateLanguageServer({ context, status, config, javaInst
 
     if (javaInstallation.javaHome) {
         env['JAVA_HOME'] = javaInstallation.javaHome;
+    }
+
+    if (javaOpts) {
+        env['JAVA_OPTS'] = javaOpts;
     }
 
     if (transportLayer == "tcp") {

--- a/src/setupParams.ts
+++ b/src/setupParams.ts
@@ -7,4 +7,5 @@ export interface ServerSetupParams {
     status: Status;
     config: vscode.WorkspaceConfiguration;
     javaInstallation: JavaInstallation;
+    javaOpts: string;
 }


### PR DESCRIPTION
If you run Visual Studio Code from a shell, this might seem redundant. If it is run directly from a GUI on the other hand, it might be difficult for some users to be able to set their `JAVA_OPTS` and have VSCode pick it up. One example is OS X where many environment variables are not sent if run through Spotlight. (yeah, I know it is possible to tweak, but let's make it more user friendly than that!). This PR aims to make it super easy for people to be able to configure their Java options by need. One big example is to combat issues like #120 and https://github.com/fwcd/kotlin-language-server/issues/441 with a custom heap size setting:

<img width="968" alt="image" src="https://user-images.githubusercontent.com/5732795/227595014-7fb360fa-b205-4a89-b4f3-b444fe8012c4.png">


It might also help users who want to tweak other settings easily like the garbage collector being used. Computers with beefy CPUs might have owners who want to use the parallel garbage collector to limit heap size at the cost of CPU usage with `-XX:+UseParallelGC`.