### PR TITLE
Add new inlay hints properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,17 +321,17 @@
                 },
                 "kotlin.inlayHints.typeHints": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Whether to give type hints as inlay hints on declaration sites or not."
                 },
                 "kotlin.inlayHints.parameterHints": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Whether to give parameter hints as inlay hints on call sites or not."
                 },
                 "kotlin.inlayHints.chainedHints": {
                     "type": "boolean",
-                    "default": true,
+                    "default": false,
                     "description": "Whether to give inlay hints on chained function calls or not."
                 }
             }

--- a/package.json
+++ b/package.json
@@ -318,6 +318,21 @@
                     "default": true,
                     "description": "[DEPRECATED] Specifies whether code completion should provide snippets (true) or plain-text items (false).",
                     "deprecationMessage": "Use 'kotlin.completion.snippets.enabled'"
+                },
+                "kotlin.inlayHints.typeHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to give type hints as inlay hints on declaration sites or not."
+                },
+                "kotlin.inlayHints.parameterHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to give parameter hints as inlay hints on call sites or not."
+                },
+                "kotlin.inlayHints.chainedHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to give inlay hints on chained function calls or not."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -322,17 +322,17 @@
                 "kotlin.inlayHints.typeHints": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to give type hints as inlay hints on declaration sites or not."
+                    "description": "Whether to provide inlay hints for types on declaration sites or not."
                 },
                 "kotlin.inlayHints.parameterHints": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to give parameter hints as inlay hints on call sites or not."
+                    "description": "Whether to provide inlay hints for parameters on call sites or not."
                 },
                 "kotlin.inlayHints.chainedHints": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Whether to give inlay hints on chained function calls or not."
+                    "description": "Whether to provide inlay hints on chained function calls or not."
                 }
             }
         }


### PR DESCRIPTION
Settings properties for inlay hints were recently added in https://github.com/fwcd/kotlin-language-server/pull/498. This PR adds these properties to be configured in VSCode.

Fixes #135 