### PR TITLE
Handle object and function literals in grammar

### DIFF
--- a/syntaxes/kotlin.tmLanguage.json
+++ b/syntaxes/kotlin.tmLanguage.json
@@ -78,13 +78,13 @@
                     "include": "#class-declaration"
                 },
                 {
-                    "include": "#object-declaration"
+                    "include": "#object"
                 },
                 {
                     "include": "#type-alias"
                 },
                 {
-                    "include": "#function-declaration"
+                    "include": "#function"
                 },
                 {
                     "include": "#variable-declaration"
@@ -320,8 +320,8 @@
                 }
             }
         },
-        "object-declaration": {
-            "match": "\\b(object)\\s+(\\b\\w+\\b|`[^`]+`)",
+        "object": {
+            "match": "\\b(object)(?:\\s+(\\b\\w+\\b|`[^`]+`))?",
             "captures": {
                 "1": {
                     "name": "storage.type.object.kotlin"
@@ -349,8 +349,8 @@
                 }
             }
         },
-        "function-declaration": {
-            "match": "\\b(fun)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?:(\\w+)\\.)?(\\b\\w+\\b|`[^`]+`)",
+        "function": {
+            "match": "\\b(fun)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?:(?:(\\w+)\\.)?(\\b\\w+\\b|`[^`]+`))?",
             "captures": {
                 "1": {
                     "name": "storage.type.function.kotlin"


### PR DESCRIPTION
This makes the grammar rules for object and function declarations flexible enough to handle literals too:

<img width="175" alt="Screenshot 2024-01-15 at 16 36 52" src="https://github.com/fwcd/vscode-kotlin/assets/30873659/f553ac86-a525-4f95-91a1-fc6ec271858c">
<img width="178" alt="Screenshot 2024-01-15 at 16 40 21" src="https://github.com/fwcd/vscode-kotlin/assets/30873659/0eb2b728-a229-4a79-8379-f4a24d197a7e">