### PR TITLE
Add `kotlin.codegen.enabled` config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,6 +241,11 @@
                     "description": "The port to which the client will attempt to connect to. A random port is used if zero. Only used if the transport layer is TCP.",
                     "default": 0
                 },
+                "kotlin.languageServer.codegen.enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable code generation to a temporary build output directory for Java interoperability (via the non-standard kotlin/buildOutputLocation LSP method). Experimental.",
+                    "default": false
+                },
                 "kotlin.languageServer.debugAttach.enabled": {
                     "type": "boolean",
                     "description": "[DEBUG] Whether the language server should listen for debuggers, i.e. be debuggable while running in VSCode. This is ONLY useful if you need to debug the language server ITSELF.",

--- a/package.json
+++ b/package.json
@@ -241,11 +241,6 @@
                     "description": "The port to which the client will attempt to connect to. A random port is used if zero. Only used if the transport layer is TCP.",
                     "default": 0
                 },
-                "kotlin.languageServer.codegen.enabled": {
-                    "type": "boolean",
-                    "description": "Whether to enable code generation to a temporary build output directory for Java interoperability (via the non-standard kotlin/buildOutputLocation LSP method). Experimental.",
-                    "default": false
-                },
                 "kotlin.languageServer.debugAttach.enabled": {
                     "type": "boolean",
                     "description": "[DEBUG] Whether the language server should listen for debuggers, i.e. be debuggable while running in VSCode. This is ONLY useful if you need to debug the language server ITSELF.",
@@ -283,6 +278,11 @@
                     "default": "off",
                     "description": "Traces the communication between VSCode and the Kotlin language server.",
                     "scope": "window"
+                },
+                "kotlin.codegen.enabled": {
+                    "type": "boolean",
+                    "description": "Whether to enable code generation to a temporary build output directory for Java interoperability (via the non-standard kotlin/buildOutputLocation LSP method). Experimental.",
+                    "default": false
                 },
                 "kotlin.compiler.jvm.target": {
                     "type": "string",


### PR DESCRIPTION
Sibling PR to https://github.com/fwcd/kotlin-language-server/pull/585, which makes code generation (for Java interoperability) optional for now.