### PR TITLE
add `cwd`, `env` and `envFile` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
                                 "description": "The current working directory. Default to the project root.",
                                 "default": "${workspaceFolder}"
                             },
-                            "envs": {
+                            "env": {
 								"type": "object",
 								"additionalProperties": {
 									"type": [

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
                             "envFile": {
 								"type": "string",
 								"description": "Environment variables file path. (usually .env)",
-								"default": {}
+								"default": "${workspaceFolder}/.env"
 							},
                             "enableJsonLogging": {
                                 "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,11 @@
 								"description": "Environment variables in key/value format. (usually { \"FOO\": \"BAR\"})",
 								"default": {}
 							},
+                            "envFile": {
+								"type": "string",
+								"description": "Environment variables file path. (usually .env)",
+								"default": {}
+							},
                             "enableJsonLogging": {
                                 "type": "boolean",
                                 "description": "Enables logging of debug server JSON messages into a file defined by 'jsonLogFile'.",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,22 @@
                                 "description": "The JVM arguments if needed by your project (usually -Dfoo=bar).",
                                 "default": ""
                             },
+                            "cwd": {
+                                "type": "string",
+                                "description": "The current working directory. Default to the project root.",
+                                "default": "${workspaceFolder}"
+                            },
+                            "envs": {
+								"type": "object",
+								"additionalProperties": {
+									"type": [
+										"string",
+										"null"
+									]
+								},
+								"description": "Environment variables in key/value format. (usually { \"FOO\": \"BAR\"})",
+								"default": {}
+							},
                             "enableJsonLogging": {
                                 "type": "boolean",
                                 "description": "Enables logging of debug server JSON messages into a file defined by 'jsonLogFile'.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
         return;
     }
 
-    const javaOpts = await findJavaOpts();
+    const initialJavaOpts = await findJavaOpts();
+    const addExportAppendix = "--add-exports jdk.jdi/com.sun.tools.jdi=ALL-UNNAMED"
+    const javaOpts = initialJavaOpts === "" ? addExportAppendix : `${addExportAppendix} ${initialJavaOpts}`;
+
     const setupParams: (status: Status) => ServerSetupParams = status => ({
         context,
         status,


### PR DESCRIPTION
Shameless copy of  #42 (Huge thanks to @thunderz99 !) with the addition of `envFile` support.

also injects `--add-exports jdk.jdi/com.sun.tools.jdi=ALL-UNNAMED` without which locally build debugAdapter refuses to start. 

Supposed to be merged together with https://github.com/fwcd/kotlin-debug-adapter/pull/90