### PR TITLE
feat: print all logs to the vscode.OutputChannel

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,10 @@ import { Status, StatusBarEntry } from './util/status';
 export async function activate(context: vscode.ExtensionContext): Promise<ExtensionApi> {
     configureLanguage();
 
+    const outputChannel = vscode.window.createOutputChannel("Kotlin");
+    LOG.appendLine = outputChannel.appendLine.bind(outputChannel);
+    context.subscriptions.push(outputChannel);
+
     const kotlinConfig = vscode.workspace.getConfiguration("kotlin");
     let langServerEnabled = kotlinConfig.get("languageServer.enabled");
     let debugAdapterEnabled = kotlinConfig.get("debugAdapter.enabled");
@@ -64,7 +68,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<Extens
         status,
         config: kotlinConfig,
         javaInstallation,
-        javaOpts
+        javaOpts,
+        outputChannel
     });
 
     let extensionApi = new ExtensionApi();

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -1,4 +1,5 @@
 import * as child_process from "child_process";
+import * as util from "util";
 import * as fs from "fs";
 import * as net from "net";
 import * as path from "path";
@@ -15,8 +16,8 @@ import { RunDebugCodeLens } from "./runDebugCodeLens";
 import { MainClassRequest, OverrideMemberRequest } from "./lspExtensions";
 
 /** Downloads and starts the language server. */
-export async function activateLanguageServer({ context, status, config, javaInstallation, javaOpts }: ServerSetupParams): Promise<KotlinApi> {
-    LOG.info('Activating Kotlin Language Server...');
+export async function activateLanguageServer({ context, status, config, javaInstallation, javaOpts, outputChannel }: ServerSetupParams): Promise<KotlinApi> {
+    LOG.info('Activating Kotlin Language Server: {}', util.inspect({ javaInstallation, javaOpts }));
     status.update("Activating Kotlin Language Server...");
     
     // Prepare language server
@@ -35,9 +36,6 @@ export async function activateLanguageServer({ context, status, config, javaInst
         }
     }
 
-    const outputChannel = vscode.window.createOutputChannel("Kotlin");
-    context.subscriptions.push(outputChannel);
-    
     const transportLayer = config.get("languageServer.transport");
     let tcpPort: number = null;
     let env: any = { ...process.env };

--- a/src/setupParams.ts
+++ b/src/setupParams.ts
@@ -8,4 +8,5 @@ export interface ServerSetupParams {
     config: vscode.WorkspaceConfiguration;
     javaInstallation: JavaInstallation;
     javaOpts: string;
+    outputChannel: vscode.OutputChannel;
 }

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -10,9 +10,11 @@ export enum LogLevel {
 
 export class Logger {
     level: LogLevel;
+    appendLine: (line: string) => void;
     
-    public constructor(level: LogLevel) {
+    public constructor(level: LogLevel, appendLine: (line: string) => void) {
         this.level = level;
+        this.appendLine = appendLine;
     }
     
     private format(msg: String, placeholders: any[]): string {
@@ -36,7 +38,7 @@ export class Logger {
     
     private log(prefix: String, level: LogLevel, msg: String, placeholders: any[]): void {
         if (level >= this.level) {
-            console.log(prefix + this.format(msg, placeholders));
+            this.appendLine(prefix + this.format(msg, placeholders));
         }
     }
     
@@ -53,4 +55,4 @@ export class Logger {
     public deepTrace(msg: String, ...placeholders: any[]): void { this.log("Extension: [D_TRACE]", LogLevel.DEEP_TRACE, msg, placeholders); }
 }
 
-export const LOG = new Logger(LogLevel.INFO);
+export const LOG = new Logger(LogLevel.DEBUG, console.log);


### PR DESCRIPTION
The goal here is to make it easier for users to diagnose why the extension isn't working for them. They can use `View: Toggle Output` and navigate to the `Kotlin` channel to investigate for themselves.