### PR TITLE
Add workspace clean command to delete classpath cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,11 @@
                 "command": "kotlin.overrideMember",
                 "title": "Override member(s)",
                 "category": "Kotlin"
+            },
+            {
+                "command": "kotlin.clean.workspace",
+                "title": "Clean Kotlin Language Server workspace",
+                "category": "Kotlin"
             }
         ],
         "menus": {

--- a/src/languageSetup.ts
+++ b/src/languageSetup.ts
@@ -131,6 +131,24 @@ export async function activateLanguageServer({ context, status, config, javaInst
         });
     });
 
+    vscode.commands.registerCommand("kotlin.clean.workspace", async (force?: boolean) => {
+        if (!force) {
+            const message = 'Are you sure you want to clean the Kotlin language server workspace?';
+            const cancel = 'Cancel';
+            const doIt = 'Reload and delete';
+            const selection = await vscode.window.showWarningMessage(message, cancel, doIt);
+            if (selection !== doIt) { // user cancelled
+                return;
+            }
+        }
+
+        // remove the workspace
+        fs.rmdirSync(storagePath, { recursive: true });
+
+        // reload the window
+        vscode.commands.executeCommand("workbench.action.reloadWindow");
+    });
+
     // Activating run/debug code lens if the debug adapter is enabled
     // and we are using 'kotlin-language-server' (other language servers
     // might not support the non-standard 'kotlin/mainClass' request)


### PR DESCRIPTION
## Changes
- Added new command `kotlin.clean.workspace` that allows users to clean the Kotlin laguage server workspace
  - This command serves as a recovery mechanism when the classpath cache becomes corrupted, often as a result of local environment inconsistencies (e.g., issues in Gradle configuration), allowing users to reset to a clean state.
- Implements a confirmation dialog to prevent accidental workspace cleaning
- Removes workspace directory and reloads window to apply changes

## Testing
- Tested manual cleaning through command palette
- Verified workspace directory is properly removed
- Confirmed window reload behavior works as expected